### PR TITLE
Remove "as_user". Not used for newer workspace apps

### DIFF
--- a/notifications/admin.py
+++ b/notifications/admin.py
@@ -59,7 +59,6 @@ class SubscriptionAdminForm(forms.ModelForm):
                 slackclient.chat_postMessage(
                     channel=x,
                     text=f':mega:  This channel just subscribed event *{self.cleaned_data.get("event")}* :newspaper:',
-                    as_user=1,
                 )
             except slack_sdk.errors.SlackApiError as e:
                 self.add_error(

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -34,9 +34,6 @@ class Event(models.Model):
             api_kwargs['unfurl_links'] = 0
         if self.slack_username:
             api_kwargs['username'] = self.slack_username
-            api_kwargs['as_user'] = 0
-        else:
-            api_kwargs['as_user'] = 1
         if self.slack_icon:
             api_kwargs['icon_emoji'] = self.slack_icon
         return api_kwargs

--- a/testapp/tests/test_blocks.py
+++ b/testapp/tests/test_blocks.py
@@ -78,7 +78,6 @@ class Test(TestCase):
             self.assertEqual(
                 call,
                 mock.call(
-                    as_user=0,
                     blocks=[{'type': 'section', 'text': {'type': 'mrkdwn', 'text': 'dull version'}}],
                     channel='@someone',
                     icon_emoji=':something:',
@@ -130,7 +129,6 @@ tesla''',
             channel='@someone',
             unfurl_links=0,
             username='NotTestBot',
-            as_user=0,
             icon_emoji=':something:',
             blocks=[
                 {'type': 'section', 'text': {'type': 'mrkdwn', 'text': '*Fruits in bag:* 1'}},

--- a/testapp/tests/test_generic.py
+++ b/testapp/tests/test_generic.py
@@ -146,5 +146,5 @@ class Test(TestCase):
         self.assertTrue(f1.is_valid())
         # assert API is called only with the new target
         slack_mock.assert_called_once_with(
-            as_user=1, channel='@otherone', text=':mega:  This channel just subscribed event *test_event* :newspaper:'
+            channel='@otherone', text=':mega:  This channel just subscribed event *test_event* :newspaper:'
         )

--- a/testapp/tests/test_sender.py
+++ b/testapp/tests/test_sender.py
@@ -47,7 +47,6 @@ class SenderTest(TestCase):
         self.assertEqual(m.to, ['at@mail.com'])
         # AND THEN the slack_api_call should be one.
         self.sc_mock.return_value.chat_postMessage.assert_called_once_with(
-            as_user=0,
             blocks=[{'type': 'section', 'text': {'type': 'mrkdwn', 'text': 'hello'}}],
             channel='@someone',
             icon_emoji=':something:',
@@ -146,7 +145,6 @@ class SenderTest(TestCase):
         self.assertEqual(m.to, ['at@mail.com'])
         # slack was properly formatted - with `message` only
         self.sc_mock.return_value.chat_postMessage.assert_called_once_with(
-            as_user=0,
             blocks=[{'type': 'section', 'text': {'type': 'mrkdwn', 'text': 'dull version'}}],
             channel='@someone',
             icon_emoji=':something:',


### PR DESCRIPTION
Including `as_user=0` as part of the notification request returns `invalid arguments` for newer workspace applications. I am proposing to remove it as it is a legacy from old Slack applications. More details about `as_user` [here](https://api.slack.com/authentication/quickstart#calling).