### PR TITLE
wip: chores: move optional dependency to required

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,9 +31,7 @@ install_requires =
     # tested with 2.3.0 and 3.0.0
     django-templated-email >= 2.3, <4
     html2text
-
-[options.extras_require]
-slack = slack_sdk==3.11.2
+    slack_sdk==3.19.5
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
As discussed in #9, this dependency should be in required dependencies, otherwise users will have to manually install the dependency to have the project running.

_Note: rebase after #10 gets done to avoid the issues in the build._

Closes #9.