### PR TITLE
setup: revert slack-sdk upgrade

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     # tested with 2.3.0 and 3.0.0
     django-templated-email >= 2.3, <4
     html2text
-    slack-sdk>=3.19.2
+    slack-sdk>=3.11.2
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     # tested with 2.3.0 and 3.0.0
     django-templated-email >= 2.3, <4
     html2text
-    slack-sdk>=3.11.2
+    slack-sdk>=3.11.2, <4
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
This is a lib and show have a wider range of dependency coverage. Solves #13.