### PR TITLE
Remove django-database-locks dependency

### DIFF
--- a/notifications/management/commands/notification_sender.py
+++ b/notifications/management/commands/notification_sender.py
@@ -1,20 +1,18 @@
 import json
 import logging
 import time
-
 from pathlib import Path
+
+from django.conf import settings
 from django.core.mail import EmailMultiAlternatives, get_connection
 from django.core.management import BaseCommand
 from slack_sdk import WebClient, errors
 
-from database_locks import locked
 from notifications.models import Notification, Subscription
-from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
 
-@locked
 class Command(BaseCommand):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,6 @@ packages = find:
 python_requires = >=3.9
 install_requires =
     Django >= 3.0, <5.0
-    # FIXME: make locks an optional dependency (and use, in the notification_sender command)
-    django-database-locks < 1
     # tested with 2.3.0 and 3.0.0
     django-templated-email >= 2.3, <4
     html2text

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -37,7 +37,6 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'database_locks',
     'notifications',
     'testapp',
 ]
@@ -121,8 +120,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_URL = '/static/'
-
-DATABASE_LOCKS_ENABLED = False
 
 try:
     from .local_settings import *


### PR DESCRIPTION
This dependency assumes too much on the implementation of the platform. The recommendation is to do a subclass of the notification_sender command with any necessary locking mechanism (which can be the django-database-locks)